### PR TITLE
add key_version to sign call

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -15,7 +15,7 @@ cargo build --package gas-station --target wasm32-unknown-unknown --release --fe
 workspace = false
 clear = true
 script = """
-mkdir -p target/near/{gas_station,oracle,signer}
+mkdir -p target/near/{gas_station,oracle,signer,local_ft,nft_key}
 cargo test
 """
 
@@ -23,7 +23,7 @@ cargo test
 workspace = false
 clear = true
 script = """
-mkdir -p target/near/{gas_station,oracle,signer}
+mkdir -p target/near/{gas_station,oracle,signer,local_ft,nft_key}
 cargo nextest run
 """
 

--- a/gas_station/src/lib.rs
+++ b/gas_station/src/lib.rs
@@ -425,7 +425,7 @@ impl Contract {
 
         #[allow(clippy::cast_possible_truncation)]
         ext_signer::ext(self.signer_contract_id.clone()) // TODO: Gas.
-            .sign(payload, &next_signature_request.key_path)
+            .sign(payload, &next_signature_request.key_path, 1)
             .then(Self::ext(env::current_account_id()).sign_next_callback(id.into(), index as u32))
     }
 

--- a/lib/src/signer.rs
+++ b/lib/src/signer.rs
@@ -24,7 +24,12 @@ use thiserror::Error;
 #[allow(clippy::ptr_arg)]
 #[ext_contract(ext_signer)]
 pub trait SignerInterface {
-    fn sign(&mut self, payload: [u8; 32], path: &String) -> PromiseOrValue<MpcSignature>;
+    fn sign(
+        &mut self,
+        payload: [u8; 32],
+        path: &String,
+        key_version: u16,
+    ) -> PromiseOrValue<MpcSignature>;
     fn public_key(&self) -> near_sdk::PublicKey;
 }
 

--- a/nft_key/tests/nft_key.rs
+++ b/nft_key/tests/nft_key.rs
@@ -13,9 +13,13 @@ async fn test_nft_key() {
                 .unwrap()
         },
         async {
-            w.dev_deploy(&near_workspaces::compile_project("../mock/signer").await.unwrap())
-                .await
-                .unwrap()
+            w.dev_deploy(
+                &near_workspaces::compile_project("../mock/signer")
+                    .await
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
         },
         async { w.dev_create_account().await.unwrap() },
         async { w.dev_create_account().await.unwrap() },
@@ -166,14 +170,26 @@ async fn test_nft_key() {
         .unwrap()
         .unwrap();
 
-    println!("Approval succeeded.");
-    println!("Bob attempting to sign with token {token_1_id}...");
+    let approval_id = bob
+        .view(nft_key.id(), "get_approval")
+        .args_json(json!({
+            "path": token_1_id,
+            "account": bob.id(),
+        }))
+        .await
+        .unwrap()
+        .json::<Option<u32>>()
+        .unwrap()
+        .unwrap();
+    println!("Approval succeeded with ID {}", approval_id);
 
+    println!("Bob attempting to sign with token {token_1_id}...");
     let bob_is_approved = bob
         .call(nft_key.id(), "ck_sign_hash")
         .args_json(json!({
             "path": token_1_id,
             "payload": msg_1,
+            "approval_id": approval_id
         }))
         .max_gas()
         .transact()


### PR DESCRIPTION
If approved, this PR closes #3.

The `key_version` field was made mandatory on the MPC-recovery contract (cf https://github.com/near/mpc-recovery/pull/509). So now this contract needs to pass along key version.It was suggested to simply hard code the value in the call-site, but we also had to update function signatures.


Note that we also fixed some unrelated broken tests and the changes have been made of two commits (for easier reviewing).

- Fix the tests: https://github.com/near/multichain-gas-station-contract/pull/4/commits/03b75d7a4bfac5eda09ddebd48246b28aecfd00e
- Fix the key version: https://github.com/near/multichain-gas-station-contract/pull/4/commits/5c539c639547fe48600f00010573acd0406f229e


I would also be willing to add a CI file to this project (in a follow up PR)

cc @encody 