### PR TITLE
Add CI (Lint, Check, Clippy, Build, Test)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,5 +35,5 @@ jobs:
       - name: Build (Release)
         run: cargo make build
       
-      - name: Build (Release)
+      - name: Run Tests
         run: cargo make test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,12 +28,16 @@ jobs:
         run: |
           rustup target add wasm32-unknown-unknown
           cargo install cargo-make
+          cargo install nextest
 
       - name: Lint & Clippy
         run: cargo make lint
 
       - name: Build (Release)
         run: cargo make build
-      
+
       - name: Run Tests
         run: cargo make test
+
+      - name: Run Nextest
+        run: cargo make nextest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,8 @@
-name: Rust
+name: Rust NEAR Contract CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   pull_request:
 
 env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,39 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install Additional Rust Tools
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo install cargo-make
+
+      - name: Lint & Clippy
+        run: cargo make lint
+
+      - name: Build (Release)
+        run: cargo make build
+      
+      - name: Build (Release)
+        run: cargo make test

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -30,8 +30,15 @@ cargo nextest run
 [tasks.clear-contract]
 workspace = false
 script_runner = "@shell"
-script = '''
+script = """
 ENTRIES=$(near contract view-storage canhazgas.testnet all as-json network-config testnet now)
 JSON="{\"entries\": $ENTRIES}"
 near contract call-function as-transaction canhazgas.testnet clear_storage json-args "$JSON" prepaid-gas '300.0 Tgas' attached-deposit '0 NEAR' sign-as
-'''
+"""
+
+[tasks.lint]
+workspace = false
+clear = true
+script = """
+cargo fmt --check && cargo clippy --all-targets --verbose -- -D warnings
+"""

--- a/nft_key/tests/nft_key.rs
+++ b/nft_key/tests/nft_key.rs
@@ -13,9 +13,13 @@ async fn test_nft_key() {
                 .unwrap()
         },
         async {
-            w.dev_deploy(&near_workspaces::compile_project("../mock/signer").await.unwrap())
-                .await
-                .unwrap()
+            w.dev_deploy(
+                &near_workspaces::compile_project("../mock/signer")
+                    .await
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
         },
         async { w.dev_create_account().await.unwrap() },
         async { w.dev_create_account().await.unwrap() },


### PR DESCRIPTION
Adding a github workflow to run the standard lint, check, clippy, build and test.

Note that this won't pass until #4 is merged.

Here is a run of the code introduced here in my fork: https://github.com/bh2smith/multichain-gas-station-contract/actions/runs/8544371001/job/23410238350