### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: Rust NEAR Contract CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ['master']
   pull_request:
 
 env:
@@ -36,4 +36,4 @@ jobs:
         run: cargo make build
 
       - name: Tests
-        run: cargo make test
+        run: cargo make nextest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,16 +28,12 @@ jobs:
         run: |
           rustup target add wasm32-unknown-unknown
           cargo install cargo-make
-          cargo install nextest
 
       - name: Lint & Clippy
         run: cargo make lint
 
-      - name: Build (Release)
+      - name: Build
         run: cargo make build
 
-      - name: Run Tests
+      - name: Tests
         run: cargo make test
-
-      - name: Run Nextest
-        run: cargo make nextest

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -15,7 +15,7 @@ cargo build --package gas-station --target wasm32-unknown-unknown --release --fe
 workspace = false
 clear = true
 script = """
-mkdir -p target/near/{gas_station,oracle,signer,local_ft,nft_key}
+mkdir -p target/near/gas_station target/near/oracle target/near/signer target/near/local_ft target/near/nft_key
 cargo test
 """
 
@@ -23,7 +23,7 @@ cargo test
 workspace = false
 clear = true
 script = """
-mkdir -p target/near/{gas_station,oracle,signer,local_ft,nft_key}
+mkdir -p target/near/gas_station target/near/oracle target/near/signer target/near/local_ft target/near/nft_key
 cargo nextest run
 """
 


### PR DESCRIPTION
Github Actions uses sh instead of bash (which does not support this notation `mkdir -p dir/{file1,file2}`).

Closes #9

cc @encody 