### PR TITLE
Mock signer: make `sign` method payable

### DIFF
--- a/mock/signer/src/lib.rs
+++ b/mock/signer/src/lib.rs
@@ -30,6 +30,7 @@ impl MockSignerContract {
 
 #[near]
 impl SignerInterface for MockSignerContract {
+    #[payable]
     fn sign(
         &mut self,
         payload: [u8; 32],


### PR DESCRIPTION
Given the discussions I'm seeing about adding the security measure of 1 yoctoNEAR, thought I'd update the mock `sign` function so we can attach NEAR.

https://github.com/near/mpc-recovery/issues/585

Helpful stuff, thanks for the making the mock contract