### PR TITLE
Update Signer Contract Interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,11 +1951,13 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 name = "lib"
 version = "0.1.0"
 dependencies = [
+ "borsh 1.5.0",
  "ethers-core",
  "getrandom 0.2.12",
  "near-sdk",
  "near-sdk-contract-tools",
  "schemars",
+ "serde",
  "sha2",
  "thiserror",
 ]
@@ -3714,18 +3716,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ resolver = "2"
 members = ["gas_station", "lib", "mock/*", "nft_key"]
 
 [workspace.dependencies]
+serde = { version = "*", features = ["derive"] }
+borsh = "1.5.0"
 ethers-core = "2.0.13"
 near-sdk = "5.1"
 near-sdk-contract-tools = { version = "3.0.2" }

--- a/gas_station/tests/tests.rs
+++ b/gas_station/tests/tests.rs
@@ -874,10 +874,10 @@ fn test_derive_new_mpc() {
     let tx: TypedTransaction = eth_transaction.into();
     let sighash = tx.sighash().to_fixed_bytes();
 
-    let mpc_signature = MpcSignature(
-        "03DAE1E75B650ABC6AD22C899FC4245A9F58E323320B7380872C1813A7DCEB0F95".to_string(),
-        "3FD2BC8430EC146E6D1B0EC64FE80EEDC0C483B95C8247FDFC5ADFC459BB3096".to_string(),
-    );
+    let mpc_signature = MpcSignature {
+        big_r: "03DAE1E75B650ABC6AD22C899FC4245A9F58E323320B7380872C1813A7DCEB0F95".to_string(),
+        s: "3FD2BC8430EC146E6D1B0EC64FE80EEDC0C483B95C8247FDFC5ADFC459BB3096".to_string(),
+    };
 
     let sig: ethers_core::types::Signature = mpc_signature.try_into().unwrap();
     let recovered_address = sig.recover(sighash).unwrap();

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+borsh.workspace = true
+serde.workspace = true
 ethers-core.workspace = true
 getrandom = { version = "0.2", features = [
     "custom",

--- a/mock/signer/src/lib.rs
+++ b/mock/signer/src/lib.rs
@@ -31,17 +31,14 @@ impl MockSignerContract {
 #[near]
 impl SignerInterface for MockSignerContract {
     #[payable]
-    fn sign(
-        &mut self,
-        payload: [u8; 32],
-        path: &String,
-        key_version: u32,
-    ) -> PromiseOrValue<MpcSignature> {
-        require!(key_version == 0, "Key version not supported");
+    fn sign(&mut self, request: lib::signer::SignRequest) -> PromiseOrValue<MpcSignature> {
+        require!(request.key_version == 0, "Key version not supported");
         let predecessor = env::predecessor_account_id();
         // This is unused, but needs to be in the sign signature.
-        let signing_key = construct_spoof_key(predecessor.as_bytes(), path.as_bytes());
-        let (sig, recid) = signing_key.sign_prehash_recoverable(&payload).unwrap();
+        let signing_key = construct_spoof_key(predecessor.as_bytes(), request.path.as_bytes());
+        let (sig, recid) = signing_key
+            .sign_prehash_recoverable(&request.payload)
+            .unwrap();
         PromiseOrValue::Value(MpcSignature::from_ecdsa_signature(sig, recid).unwrap())
     }
 

--- a/nft_key/src/lib.rs
+++ b/nft_key/src/lib.rs
@@ -1,6 +1,6 @@
 use lib::{
     chain_key::{ext_chain_key_token_approval_receiver, ChainKeyToken, ChainKeyTokenApproval},
-    signer::{ext_signer, MpcSignature},
+    signer::{ext_signer, MpcSignature, SignRequest},
     Rejectable,
 };
 use near_sdk::{
@@ -147,11 +147,11 @@ impl ChainKeyToken for NftKeyContract {
         PromiseOrValue::Promise(
             ext_signer::ext(self.signer_contract_id.clone())
                 .with_unused_gas_weight(10)
-                .sign(
-                    payload.try_into().unwrap(),
-                    &format!("{token_id},{path}"),
-                    0,
-                )
+                .sign(SignRequest {
+                    payload: payload.try_into().unwrap(),
+                    path: format!("{token_id},{path}"),
+                    key_version: 0,
+                })
                 .then(
                     Self::ext(env::current_account_id())
                         .with_static_gas(near_sdk::Gas::from_tgas(3))


### PR DESCRIPTION
The sign method interface has recently been 
updated: https://github.com/near/mpc-recovery/pull/613/files
and deployed: https://testnet.nearblocks.io/txns/E2fQfcdqPARCnok7RFAJ6WXur3SDKEB7ESgYiH5zHfBT

This PR introduces the appropriate changes to the interface.

cc @encody 

## Test Plan

Existing CI (no logical changes made). 