### PR TITLE
Update mock signer

### DIFF
--- a/lib/src/signer.rs
+++ b/lib/src/signer.rs
@@ -26,12 +26,40 @@ use thiserror::Error;
 pub trait SignerInterface {
     fn sign(
         &mut self,
-        payload: [u8; 32],
-        path: &String,
-        key_version: u32,
-    ) -> PromiseOrValue<MpcSignature>;
+        request: SignRequest
+    ) -> PromiseOrValue<MpcSignatureResponse>;
     fn public_key(&self) -> near_sdk::PublicKey;
     fn latest_key_version(&self) -> u32;
+}
+
+/// No published lib crate, so taken from:
+/// https://github.com/near/mpc/blob/9e73c2e352e5e2213032857cca4e7d0dc2af3508/chain-signatures/contract/src/primitives.rs#L211-L216
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(crate = "near_sdk::serde")]
+pub struct SignRequest {
+    pub payload: [u8; 32],
+    pub path: String,
+    pub key_version: u32,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(crate = "near_sdk::serde")]
+pub struct SigBigR {
+    pub affine_point: String
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(crate = "near_sdk::serde")]
+pub struct SigS {
+    pub scalar: String
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(crate = "near_sdk::serde")]
+pub struct MpcSignatureResponse {
+    pub big_r: SigBigR,
+    pub s: SigS,
+    pub recovery_id: u32,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
Similar to #18, this is another community pull request. The mock signer has been out of date and this pull request modifies a few things to return a result identical to what we can expect from the contract currently deployed to `v5.multichain-mpc-dev.testnet`.

You may modify and run this command to see the result:

```
near call v5.multichain-mpc-dev.testnet sign '{"request":{"payload":[6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6],"path":"f/o/o","key_version":0}}' --accountId mike.testnet --gas 300000000000000 --depositYocto 1
```

and you will see this result:

```js
{
  big_r: {
    affine_point: '03281F016985A6E06BEAE5AC01D7B927EB7EF1FFBE2BCDBF2A1E37BEAF571E37A8'
  },
  s: {
    scalar: '49F06C0CF14005A15E8B65AFFFCFA0A77C9A205BDF1C135426D35A8F69F12C61'
  },
  recovery_id: 1
}
```

This pull request quickly catches up the sign method with the latest breaking changes to the arguments, and the breaking changes involved in the structure of the response. See this screenshot comparing the two:

![Screenshot 2024-06-19 at 5 02 56 PM](https://github.com/near/multichain-gas-station-contract/assets/1042667/2f7ee3db-5d32-4f02-a47c-fd7f1f8ae100)

On the left window, you see the mock contract from this pull request built (not optimized) and deployed to `mock-mpc.mike.testnet`, which folks are free to use instead of deploying their own, obviously.

At the time of this writing, it feels rather important for developers to have an alternate contract since the v2 contract (`v2.multichain-mpc.testnet`) hasn't been updated to allow for the 1 yoctoNEAR requirement. So the contract at that address is unfortunately, not "forward-compatible" because it will throw an error when a builder attempts to develop a proper workflow in line with security concerns.

![Screenshot 2024-06-19 at 5 15 58 PM](https://github.com/near/multichain-gas-station-contract/assets/1042667/b7d57892-7644-4166-8d46-a4ebce130e9c)

Recommendation to include a brief page in docs about how a builder can use a mock contract.